### PR TITLE
change of ADMIN privilege management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### zeronet-conservancy 0.7.3+ (master)
+maintainers: @caryoscelus
+- don't grant ADMIN permission to home or update pages
+- allow granting ADMIN permission via `--admin_pages` command line option
+
 ### zeronet-conservancy 0.7.3 (2022-01-21) Rev5000
 maintainers: @caryoscelus
 - forked from the latest py3 branch of ZeroNet

--- a/src/Config.py
+++ b/src/Config.py
@@ -260,6 +260,7 @@ class Config(object):
                                  metavar='address')
         self.parser.add_argument('--updatesite', help='Source code update site', default='1uPDaT3uSyWAPdCv1WkMb5hBQjWSNNACf',
                                  metavar='address')
+        self.parser.add_argument('--admin_pages', help='Pages with admin privileges', default=[], metavar='address', nargs='*')
         self.parser.add_argument('--dist_type', help='Type of installed distribution', default='source')
 
         self.parser.add_argument('--size_limit', help='Default site size limit in MB', default=10, type=int, metavar='limit')

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -110,8 +110,8 @@ class Site(object):
             if config.download_optional == "auto":
                 self.settings["autodownloadoptional"] = True
 
-        # Add admin permissions to homepage
-        if self.address in (config.homepage, config.updatesite) and "ADMIN" not in self.settings["permissions"]:
+        # Add admin permissions according to user settings
+        if self.address in config.admin_pages and "ADMIN" not in self.settings["permissions"]:
             self.settings["permissions"].append("ADMIN")
 
         return


### PR DESCRIPTION
- don't grant ADMIN permission to home or update pages
- allow granting ADMIN permission via `--admin_pages` command line option