### PR TITLE
remove mention of python-3.6 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-gevent==1.4.0; python_version <= "3.6"
-greenlet==0.4.16; python_version <= "3.6"
-gevent>=20.9.0; python_version >= "3.7"
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+gevent>=20.9.0
 msgpack>=0.4.4
 base58
 merkletools
@@ -14,4 +13,3 @@ maxminddb
 rich
 defusedxml>=0.7
 pyaes
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
after analyzing the old version of requirements.txt, it becomes obvious that any real python 3.6.X versions would fail to install required package, and since no one complained that means there are no <py3.7 users now