### PR TITLE
Changed file_size_limit from 10 MB to 2048 MB

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -252,7 +252,7 @@ class Config(object):
         self.parser.add_argument('--dist_type', help='Type of installed distribution', default='source')
 
         self.parser.add_argument('--size_limit', help='Default site size limit in MB', default=10, type=int, metavar='limit')
-        self.parser.add_argument('--file_size_limit', help='Maximum per file size limit in MB', default=10, type=int, metavar='limit')
+        self.parser.add_argument('--file_size_limit', help='Maximum per file size limit in MB', default=2048, type=int, metavar='limit')
         self.parser.add_argument('--connected_limit', help='Max connected peer per site', default=8, type=int, metavar='connected_limit')
         self.parser.add_argument('--global_connected_limit', help='Max connections', default=512, type=int, metavar='global_connected_limit')
         self.parser.add_argument('--workers', help='Download workers per site', default=5, type=int, metavar='workers')


### PR DESCRIPTION
ZeroNet skips loading big non-optional files (more than 10 MB).

> if file_info.get("size", 0) > config.file_size_limit * 1024 * 1024:
            self.log.debug(
                "File size %s too large: %sMB > %sMB, skipping..." %
                (inner_path, file_info.get("size", 0) / 1024 / 1024, config.file_size_limit)
            )
            return False
        else:
            return True

Related: [Discussion](http://127.0.0.1:43110/1NFjL6KmJYwojYMat8RXCPo2JWMvNzfHAk/?Post:2), [Test zite with 23MB video](http://127.0.0.1:43110/1Box3D1epiea3D3RF1nZ6Zr9LGM3iBMQXx/).
