### PR TITLE
Fix error when closing sockets

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -181,7 +181,8 @@ class UiServer:
             from Debug import DebugReloader
             DebugReloader.watcher.stop()
 
-        self.server.socket.close()
+        for socket in self.server.sockets:
+            socket.stop()
         self.server.stop()
         self.running = False
         time.sleep(1)


### PR DESCRIPTION
This occurs when ZeroNet is started and you send a SIGINT signal (for example with CTRL+C).