### PR TITLE
Fix UiServer.getPosted hanging in some circumstances

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -231,8 +231,12 @@ class UiRequest(object):
     # Return: <dict> Posted variables
     def getPosted(self):
         if self.env['REQUEST_METHOD'] == "POST":
+            try:
+                content_length = int(self.env.get('CONTENT_LENGTH', 0))
+            except ValueError:
+                content_length = 0
             return dict(urllib.parse.parse_qsl(
-                self.env['wsgi.input'].readline().decode()
+                self.env['wsgi.input'].read(content_length).decode()
             ))
         else:
             return {}


### PR DESCRIPTION
fixes #198

while it's not exactly clear what causes the difference in behaviour, but under certain conditions UiServer.getPosted used to hang trying to readline() POST request (e.g. from UiPassword login). using read(CONTENT_LENGTH) seems to fix the issue