### PR TITLE
Rewrite cross-site and cross-host requests detection

### DIFF
--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -74,7 +74,7 @@ else if (window.opener && window.opener.location.toString()) {
 
 
 <!-- Site Iframe -->
-<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups allow-modals allow-presentation allow-pointer-lock allow-popups-to-escape-sandbox {sandbox_permissions}" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" oallowfullscreen="true" msallowfullscreen="true"></iframe>
+<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups allow-modals allow-presentation allow-pointer-lock allow-popups-to-escape-sandbox allow-same-origin {sandbox_permissions}" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" oallowfullscreen="true" msallowfullscreen="true" referrerpolicy="same-origin"></iframe>
 
 <!-- Site info -->
 <script id="script_init" nonce="{script_nonce}">


### PR DESCRIPTION
Make sure browsers send referrers so we can track cross-site requests (could be used to identify which sites user hosts)

This breaks /raw because there are no referrers there

fixes #227
fixes #223
fixes #224