### PR TITLE
Fix command-line argument style (use dashes instead of underscores)

### DIFF
--- a/plugins/AnnounceLocal/AnnounceLocalPlugin.py
+++ b/plugins/AnnounceLocal/AnnounceLocalPlugin.py
@@ -142,6 +142,6 @@ class FileServerPlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("AnnounceLocal plugin")
-        group.add_argument('--broadcast_port', help='UDP broadcasting port for local peer discovery', default=1544, type=int, metavar='port')
+        group.add_argument('--broadcast-port', help='UDP broadcasting port for local peer discovery', default=1544, type=int, metavar='port')
 
         return super(ConfigPlugin, self).createArguments()

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -185,6 +185,6 @@ class FileServerPlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("AnnounceShare plugin")
-        group.add_argument('--working_shared_trackers_limit', help='Stop discovering new shared trackers after this number of shared trackers reached', default=5, type=int, metavar='limit')
+        group.add_argument('--working-shared-trackers-limit', help='Stop discovering new shared trackers after this number of shared trackers reached', default=5, type=int, metavar='limit')
 
         return super(ConfigPlugin, self).createArguments()

--- a/plugins/Benchmark/BenchmarkPlugin.py
+++ b/plugins/Benchmark/BenchmarkPlugin.py
@@ -413,7 +413,7 @@ class ConfigPlugin(object):
         back = super(ConfigPlugin, self).createArguments()
         if self.getCmdlineValue("test") == "benchmark":
             self.test_parser.add_argument(
-                '--num_multipler', help='Benchmark run time multipler',
+                '--num-multipler', help='Benchmark run time multipler',
                 default=1.0, type=float, metavar='num'
             )
             self.test_parser.add_argument(
@@ -422,7 +422,7 @@ class ConfigPlugin(object):
             )
         elif self.getCmdlineValue("test") == "portChecker":
             self.test_parser.add_argument(
-                '--func_name', help='Name of open port checker function',
+                '--func-name', help='Name of open port checker function',
                 default=None, metavar='func_name'
             )
         return back

--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -837,7 +837,7 @@ class SitePlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("Bigfile plugin")
-        group.add_argument('--autodownload_bigfile_size_limit', help='Also download bigfiles smaller than this limit if help distribute option is checked', default=10, metavar="MB", type=int)
-        group.add_argument('--bigfile_size_limit', help='Maximum size of downloaded big files', default=False, metavar="MB", type=int)
+        group.add_argument('--autodownload-bigfile-size-limit', help='Also download bigfiles smaller than this limit if help distribute option is checked', default=10, metavar="MB", type=int)
+        group.add_argument('--bigfile-size-limit', help='Maximum size of downloaded big files', default=False, metavar="MB", type=int)
 
         return super(ConfigPlugin, self).createArguments()

--- a/plugins/OptionalManager/OptionalManagerPlugin.py
+++ b/plugins/OptionalManager/OptionalManagerPlugin.py
@@ -247,7 +247,7 @@ class SitePlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("OptionalManager plugin")
-        group.add_argument('--optional_limit', help='Limit total size of optional files', default="10%", metavar="GB or free space %")
-        group.add_argument('--optional_limit_exclude_minsize', help='Exclude files larger than this limit from optional size limit calculation', default=20, metavar="MB", type=int)
+        group.add_argument('--optional-limit', help='Limit total size of optional files', default="10%", metavar="GB or free space %")
+        group.add_argument('--optional-limit-exclude-minsize', help='Exclude files larger than this limit from optional size limit calculation', default=20, metavar="MB", type=int)
 
         return super(ConfigPlugin, self).createArguments()

--- a/plugins/Zeroname/SiteManagerPlugin.py
+++ b/plugins/Zeroname/SiteManagerPlugin.py
@@ -62,7 +62,7 @@ class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("Zeroname plugin")
         group.add_argument(
-            "--bit_resolver", help="ZeroNet site to resolve .bit domains",
+            "--bit-resolver", help="ZeroNet site to resolve .bit domains (deprecated)",
             default="1GnACKctkJrGWHTqxk9T9zXo2bLQc2PDnF", metavar="address"
         )
 

--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -272,7 +272,7 @@ class UiWebsocketPlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("Multiuser plugin")
-        group.add_argument('--multiuser_local', help="Enable unsafe Ui functions and write users to disk", action='store_true')
-        group.add_argument('--multiuser_no_new_sites', help="Denies adding new sites by normal users", action='store_true')
+        group.add_argument('--multiuser-local', help="Enable unsafe Ui functions and write users to disk", action='store_true')
+        group.add_argument('--multiuser-no-new-sites', help="Denies adding new sites by normal users", action='store_true')
 
         return super(ConfigPlugin, self).createArguments()

--- a/plugins/disabled-UiPassword/UiPasswordPlugin.py
+++ b/plugins/disabled-UiPassword/UiPasswordPlugin.py
@@ -159,7 +159,7 @@ class UiRequestPlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("UiPassword plugin")
-        group.add_argument('--ui_password', help='Password to access UiServer', default=None, metavar="password")
+        group.add_argument('--ui-password', help='Password to access UiServer', default=None, metavar="password")
 
         return super(ConfigPlugin, self).createArguments()
 


### PR DESCRIPTION
fixes #257 