### PR TITLE
Fix hanging on repeated cross-site requests

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -156,7 +156,7 @@ class UiRequest:
         if self.isCrossOriginRequest():
             # we are still exposed by answering on port
             self.log.warning('Cross-origin request detected. Someone might be trying to analyze your 0net usage')
-            return []
+            return self.error403()
 
         # Restict Ui access by ip
         if config.ui_restrict and self.env['REMOTE_ADDR'] not in config.ui_restrict:


### PR DESCRIPTION
Certain sites (ZeroBlog++ in particular) seem to be very keen on trying to reload cross-site requrested images, which leads to 0net hanging until those requests are dropped. Thus we revert to returning error on bad requests.

NOTE: user privacy should be considered, DO NOT merge before checking that no more info about local zeronet is leaked