### PR TITLE
Simplified cors 2

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -162,7 +162,7 @@ class UiServer:
             return ui_request.route(path)
         except Exception as err:
             logging.debug(f"UiRequest @ site error: {Debug.formatException(err)}")
-            return ui_request.error500('Error while trying to server site data')
+            return ui_request.error500('Error while trying to serve site data')
 
     def startSiteServer(self):
         self.site_server = WSGIServer((self.ip, self.site_port), self.handleSiteRequest, log=self.log)


### PR DESCRIPTION
Allow cross-site embedding without "cors-" prefix as long as CORS read permission is granted. This is done for
compatibility with sites that relied on lack of enforcing of cross-site isolation in previous ZeroNet versions.

fixes #259