### PR TITLE
fix siteSign error

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import gevent
 from Config import config


### PR DESCRIPTION
```
- Unhandled exception: name 'os' is not defined
Traceback (most recent call last):
  File "/home/foo/zeronet-conservancy/zeronet.py", line 28, in launch
    main.start()
  File "/home/foo/zeronet-conservancy/src/main.py", line 203, in start
    actions.call(config.action, action_kwargs)
  File "/home/foo/zeronet-conservancy/src/Actions.py", line 13, in call
    back = func(**kwargs)
           ^^^^^^^^^^^^^^
  File "/home/foo/zeronet-conservancy/src/Actions.py", line 131, in siteSign
    if os.path.isabs(inner_path):
       ^^
NameError: name 'os' is not defined
```