### PR TITLE
Fix: Unhandled exception: name 'time' is not defined - Actions.py

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -347,6 +347,7 @@ class Actions:
 
     def sitePublishFallback(self, site, peer_ip, peer_port, inner_paths, err):
         import main
+        import time
         if err is not None:
             logging.info(f"Can't connect to local websocket client: {err}")
         logging.info("Publish using fallback mechanism. "


### PR DESCRIPTION
### Step 1: Please describe your environment

  * ZeroNet version: v0.7.10+
  * Operating system: Debian 12 (stable - Bookworm)

### Step 2: Describe the problem:

Installed like this

> Git clone ZNC; cd ZNCdirectory
> /usr/bin/python3 -m venv .venv
> source .venv/bin/activate && python3 -m pip install -r requirements.txt

When trying to publish the site from CLI ./zeronet.py sitePublish siteAddressHere (or using VENV python path)

on Linux Debian 12 (stable version, Bookworm), there is an error:

```
Can't connect to local websocket client: [Errno 111] Connection refused
Unhandled exception: name 'time' is not defined
NameError: name 'time' is not defined
```

Full output is [HERE](https://bin.disroot.org/?97ba345aae43d053#2PXf6xktwUnr7nCCYgukjw3x9maikTwcR7rLnXbMztEx) please.

I have added "import time" to the same place of the Actions.py as @d47081 added "import main", it hide the exception.

Now the only issue (not error) is:
```
- Connecting to ws://*:12345/Websocket?wrapper_key=***
- Can't connect to local websocket client: [Errno 111] Connection refused
```