### PR TITLE
Allow start-venv.sh being executed from any location

### DIFF
--- a/start-venv.sh
+++ b/start-venv.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+SAMEDIR="$(dirname $(realpath $0))"; cd "$SAMEDIR" || exit # directory where this .sh file is located
 VENVPATH="venv/bin/activate"
 
 if [ ! -f "$VENVPATH" ]; then


### PR DESCRIPTION
If the start-venv.sh script file is supposed to be executed from any path, then the commands in it, needs to be executed in same directory where the script is located, not the directory from which script is executed..