### PR TITLE
Fix TypeError when logging GeoIP database paths in SidebarPlugin

### DIFF
--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -695,7 +695,7 @@ class UiWebsocketPlugin(object):
                 return path
 
         self.log.info("GeoIP database not found at [%s]. Downloading to: %s",
-                " ".join(db_paths), data_dir_db_path)
+            " ".join(str(p) for p in db_paths), data_dir_db_path)
         if self.downloadGeoLiteDb(data_dir_db_path):
             return data_dir_db_path
         return None


### PR DESCRIPTION
This PR fixes a `TypeError` that occurred when selecting "Stats" from the homepage. The error message was:

```
ERROR Site:191Caz..g2um WebSocket handleRequest error: TypeError: sequence item 1: expected str instance, 
PosixPath found in UiWebsocket.py line 82 > 240 > ChartPlugin.py line 56 > SidebarPlugin.py line 706 > 
util/Noparallel.py line 62 > 55 > SidebarPlugin.py line 698

{"cmd":"chartGetPeerLocations","params":[],"wrapper_nonce":
"6f6d81def0ce3bd18b549d092cb03ff1a7194a5ea8ccf79b4342aef898d2c8a9","id":92}
```

**Cause:**  
The issue was caused by attempting to use `" ".join(db_paths), data_dir_db_path)` where `db_paths` is a list that may contain `PosixPath` objects. Python’s `str.join()` requires all items in the sequence to be strings, but `PosixPath` is not a string, resulting in the error.

**Fix:**  
We now explicitly convert each path in `db_paths` to a string before joining:
```
self.log.info("GeoIP database not found at [%s]. Downloading to: %s",
        " ".join(str(p) for p in db_paths), data_dir_db_path)
```

**Additional Context:**  
This error only occurs if the GeoLite2-City.mmdb file is **not present** in any of the checked locations (such as `/usr/share/GeoIP/GeoLite2-City.mmdb`). 
- **If `/usr/share/GeoIP/GeoLite2-City.mmdb` is present and valid:**  
  The code finds it, uses it, and does **not** log the "not found" message, so the error does not occur.
- **If it is missing:**  
  The code tries to log the missing paths, triggering the TypeError.  
  **Error occurs.**

This fix ensures that the error will not be triggered regardless of whether the database file is present.

**Impact:**  
- Fixes the TypeError when accessing Stats from the homepage.
- Ensures logging works correctly regardless of the type of objects in `db_paths`.